### PR TITLE
Fix Data Generator stops working after exception while inserting data

### DIFF
--- a/src/data_generator/data_generator.py
+++ b/src/data_generator/data_generator.py
@@ -167,7 +167,16 @@ def insert_routine(last_ts):
 
     runtime_metrics["rows"] += len(batch)
     runtime_metrics["metrics"] += len(batch) * len(get_sub_element("metrics").keys())
-    helper.execute_timed_function(db_writer.insert_stmt, timestamps, batch)
+
+    try:
+        helper.execute_timed_function(db_writer.insert_stmt, timestamps, batch)
+    except Exception as e:
+        # if an exception is thrown while inserting we don't want the whole data_generator to crash
+        # as the values have not been inserted we remove them from our runtime_metrics
+        # TODO: more sophistic error handling on db_writer level
+        logging.error(e)
+        runtime_metrics["rows"] -= len(batch)
+        runtime_metrics["metrics"] -= len(batch) * len(get_sub_element("metrics").keys())
 
     if batch_size_automator.auto_batch_mode:
         duration = time.time() - start


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

During some testing with AWS timestream we encountered errors while ingesting which completely broke data generator execution. To handle this problem data that fails to be inserted is omitted and the data_generator continues inserting new values.
