### PR TITLE
Refactor console output for query_timer to use curses for better live output

### DIFF
--- a/src/query_timer/query_timer.py
+++ b/src/query_timer/query_timer.py
@@ -29,7 +29,7 @@ token = os.getenv("TOKEN", "")
 concurrency = os.getenv("CONCURRENCY", 10)
 iterations = os.getenv("ITERATIONS", 10)
 quantile_list = os.getenv("QUANTILES", "50,60,75,90,99")
-query = os.getenv("QUERY", 'SELECT * FROM "data_generator_test"."temperature" LIMIT 100')
+query = os.getenv("QUERY", 'SELECT * FROM table LIMIT 100')
 model = {"value": "none"}
 
 query_results = []


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
To have an overview on how query_timer is performing while it's running the print statements where changed to `curses` library to ensure proper formatting.

Also the rates metric was redefined to represent average amount of queries executed each second.
