### PR TITLE
Fix order of BSA arguments

### DIFF
--- a/src/data_generator/data_generator.py
+++ b/src/data_generator/data_generator.py
@@ -53,7 +53,9 @@ elif config.database == 5:  # timestream
 else:
     db_writer = None
 
-batch_size_automator = BatchSizeAutomator(config.batch_size, config.ingest_mode, config.id_end - config.id_start + 1)
+batch_size_automator = BatchSizeAutomator(batch_size=config.batch_size,
+                                          active=bool(config.ingest_mode),
+                                          data_batch_size=(config.id_end - config.id_start + 1))
 
 runtime_metrics = {"rows": 0, "metrics": 0, "batch_size": config.batch_size}
 edges = {}


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

This PR fixes an Error where the data_batch_size was wrongfully passed as the `active` argument of the BSA constructor.

