### PR TITLE
Fix partitioning of distributed hypertable for timescale implementation

### DIFF
--- a/src/modules/mssql_db_writer.py
+++ b/src/modules/mssql_db_writer.py
@@ -2,14 +2,14 @@ import pyodbc
 from tictrack import timed_function
 from modules.db_writer import DbWriter
 from datetime import datetime
-from datetime_truncate import truncate
 
 
 class MsSQLDbWriter(DbWriter):
     def __init__(self, host, username, password, db_name, model, port=1433, table_name=None):
         super().__init__()
         driver = '{ODBC Driver 17 for SQL Server}'
-        self.conn = pyodbc.connect(f"DRIVER={driver};SERVER={host};PORT={port};DATABASE={db_name};UID={username};PWD={password}")
+        connection_string = f"DRIVER={driver};SERVER={host},{port};DATABASE={db_name};UID={username};PWD={password};CONNECTION TIMEOUT=170000;"
+        self.conn = pyodbc.connect(connection_string)
         self.cursor = self.conn.cursor()
         self.cursor.fast_executemany = True
         self.model = model

--- a/src/test/test_mssql_db_writer.py
+++ b/src/test/test_mssql_db_writer.py
@@ -25,7 +25,7 @@ def test_prepare_database1(mock_connect):
     mock_connect.return_value = conn
     conn.cursor.return_value = cursor
     db_writer = MsSQLDbWriter("localhost", "mssql", "password", "test", test_model)
-    connection_string = "DRIVER={ODBC Driver 17 for SQL Server};SERVER=localhost;PORT=1433;DATABASE=test;UID=mssql;PWD=password"
+    connection_string = 'DRIVER={ODBC Driver 17 for SQL Server};SERVER=localhost,1433;DATABASE=test;UID=mssql;PWD=password;CONNECTION TIMEOUT=170000;'
     mock_connect.assert_called_with(connection_string)
     # Test Case 1:
     db_writer.prepare_database()


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

partitioning for distributed hypertables in timescale shouldn't be based on time intervals (like in the none distributed version) but on tags see [here](https://docs.timescale.com/v2.0/using-timescaledb/distributed-hypertables). 
To fix this in the short run we partition by the lowest tag, because it seems the most likely to be included in a group by clause.
In the long run this should be possible to be set in the model and the lowest level tag is the default if not set in the model.