### PR TITLE
Dependencies: Re-add pyodbc

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ requires = [
     "dnspython<3",
     "numpy<1.27",
     "pgcopy<1.7",
-    # "pyodbc<5",
+    "pyodbc<6",
     "tqdm<5",
     "cloup<1",
 ]


### PR DESCRIPTION
## About

5b6ece9b14 removed pyodbc, because of some woes. Hereby, we are trying to re-add it again.
