### PR TITLE
Add missing `default_database` attribute to datasource adapters

### DIFF
--- a/tsperf/adapter/influxdb.py
+++ b/tsperf/adapter/influxdb.py
@@ -36,6 +36,7 @@ logger = logging.getLogger(__name__)
 
 class InfluxDbAdapter(AbstractDatabaseInterface):
     default_address = "http://localhost:8086/"
+    default_database = "tsperf"
 
     def __init__(
         self,

--- a/tsperf/adapter/postgresql.py
+++ b/tsperf/adapter/postgresql.py
@@ -36,6 +36,7 @@ from tsperf.write.config import DataGeneratorConfig
 class PostgreSQLAdapter(AbstractDatabaseInterface, DatabaseInterfaceMixin):
     default_address = "localhost:5432"
     default_username = "postgres"
+    default_database = "tsperf"
     default_query = "SELECT 1;"
 
     def __init__(

--- a/tsperf/adapter/timescaledb.py
+++ b/tsperf/adapter/timescaledb.py
@@ -39,6 +39,7 @@ logger = logging.getLogger(__name__)
 class TimescaleDbAdapter(AbstractDatabaseInterface, DatabaseInterfaceMixin):
     default_address = "localhost:5432"
     default_username = "postgres"
+    default_database = "tsperf"
     default_query = "SELECT 1;"
 
     def __init__(


### PR DESCRIPTION
What the title says.