### PR TITLE
Dependencies: Update to `crate==1.0.0dev0` for validation purposes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("README.md", "r") as fh:
 requires = [
     "blessed<1.21",
     "boto3<1.35",
-    "crate==0.35.2",
+    "crate==1.0.0dev0",
     "prometheus-client<0.11",
     "urllib3<3",
     "datetime-truncate<2",


### PR DESCRIPTION
## About
> The [CrateDB SQLAlchemy dialect](https://github.com/crate-workbench/sqlalchemy-cratedb) needs more love, so it was separated from the [DBAPI HTTP driver](https://github.com/crate/crate-python). This patch verifies the migration does not break anything, by updating to a pre-release of the upcoming `crate-1.0.0` package.

## References
- https://github.com/crate/roadmap/issues/85#issuecomment-2163344121
